### PR TITLE
Fix to make mkdir work with "/" on Windows machine 

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "compress"
   ],
   "scripts": {
-    "clean": "rm -f dist/{css/*,js/*,images/*}",
+    "clean": "rimraf dist/{css/*,js/*,images/*}",
     "autoprefixer": "postcss -u autoprefixer -r dist/css/*",
     "scss": "node-sass --output-style compressed -o dist/css src/scss",
     "lint": "eslint src/js",
@@ -49,6 +49,7 @@
     "npm-run-all": "^2.1.1",
     "onchange": "^2.4.0",
     "postcss-cli": "^2.5.2",
+    "rimraf": "^2.5.4",
     "svg-sprite-generator": "0.0.7",
     "svgo": "^0.6.6",
     "uglify-js": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -9,15 +9,22 @@
     "url": "https://github.com/damonbauer/npm-build-boilerplate"
   },
   "bugs": "https://github.com/damonbauer/npm-build-boilerplate/issues",
-  "keywords": ["npm", "scripts", "npm scripts", "watch", "minify", "compress"],
+  "keywords": [
+    "npm",
+    "scripts",
+    "npm scripts",
+    "watch",
+    "minify",
+    "compress"
+  ],
   "scripts": {
     "clean": "rm -f dist/{css/*,js/*,images/*}",
     "autoprefixer": "postcss -u autoprefixer -r dist/css/*",
     "scss": "node-sass --output-style compressed -o dist/css src/scss",
     "lint": "eslint src/js",
-    "uglify": "mkdir -p dist/js && uglifyjs src/js/*.js -m -o dist/js/app.js && uglifyjs src/js/*.js -m -c -o dist/js/app.min.js",
+    "uglify": "mkdirp dist/js -p && uglifyjs src/js/*.js -m -o dist/js/app.js && uglifyjs src/js/*.js -m -c -o dist/js/app.min.js",
     "imagemin": "imagemin src/images/* -o dist/images",
-    "icons": "svgo -f src/images/icons && mkdir -p dist/images && svg-sprite-generate -d src/images/icons -o dist/images/icons.svg",
+    "icons": "svgo -f src/images/icons && mkdirp dist/images -p && svg-sprite-generate -d src/images/icons -o dist/images/icons.svg",
     "serve": "browser-sync start --server --files \"dist/css/*.css, dist/js/*.js, **/*.html, !node_modules/**/*.html\"",
     "build:css": "npm run scss && npm run autoprefixer",
     "build:js": "npm run lint && npm run uglify",
@@ -37,6 +44,7 @@
     "eslint-plugin-promise": "^1.3.0",
     "eslint-plugin-standard": "^1.3.2",
     "imagemin-cli": "^3.0.0",
+    "mkdirp": "^0.5.1",
     "node-sass": "^3.7.0",
     "npm-run-all": "^2.1.1",
     "onchange": "^2.4.0",


### PR DESCRIPTION
When using `mkdir -p dist/js` on my windows machine I get the following error `The syntax of the command is incorrect`

I've added the npm package `mkdirp` and updated `uglify` and `icons` run scripts to create the same necessary folders

Note: Have not tested updated on Apple machine yet
